### PR TITLE
Speedup things

### DIFF
--- a/miniid.go
+++ b/miniid.go
@@ -28,11 +28,14 @@ func encodeBase62(num uint64) string {
 		return string(alphabet[0])
 	}
 
-	result := make([]byte, 0, 16)
-	for num > 0 {
+	const maxLen = 16
+	var result [maxLen]byte
+	i := maxLen - 1
+
+	for ; num > 0; i-- {
 		rem := num % base
-		result = append([]byte{alphabet[rem]}, result...)
+		result[i] = alphabet[rem]
 		num /= base
 	}
-	return string(result)
+	return string(result[i+1:])
 }

--- a/miniid_test.go
+++ b/miniid_test.go
@@ -63,3 +63,14 @@ func TestGeneratorConcurrency(t *testing.T) {
 		t.Fatalf("Expected %d unique IDs, got %d", n, len(seen))
 	}
 }
+
+func BenchmarkGenerate(b *testing.B) {
+	g := New(1000)
+
+	for b.Loop() {
+		s := g.Next()
+		if s == "" {
+			b.Fail()
+		}
+	}
+}


### PR DESCRIPTION
```
$ go-perftuner bstat a.txt b.txt 
name         old time/op    new time/op    delta
Generate-10     104ns ± 2%      45ns ± 0%  -56.40%  (p=0.000 n=10+9)

name         old alloc/op   new alloc/op   delta
Generate-10     47.0B ± 0%      4.0B ± 0%  -91.49%  (p=0.000 n=10+10)

name         old allocs/op  new allocs/op  delta
Generate-10      7.00 ± 0%      1.00 ± 0%  -85.71%  (p=0.000 n=10+10)
```